### PR TITLE
Fix delete document webhook payload to include document id

### DIFF
--- a/src/components/notebook/DocumentsSidebar.tsx
+++ b/src/components/notebook/DocumentsSidebar.tsx
@@ -28,7 +28,10 @@ const DocumentsSidebar = ({ notebookId }: DocumentsSidebarProps) => {
 
   const confirmDelete = () => {
     if (selectedDocument) {
-      deleteDocument({ documentName: selectedDocument.name });
+      deleteDocument({
+        documentId: selectedDocument.id,
+        documentName: selectedDocument.name,
+      });
       setShowDeleteDialog(false);
       setSelectedDocument(null);
     }

--- a/src/hooks/useDocuments.tsx
+++ b/src/hooks/useDocuments.tsx
@@ -95,7 +95,13 @@ export const useDocuments = (notebookId?: string) => {
   }, [notebookId, user, queryClient]);
 
   const deleteDocument = useMutation({
-    mutationFn: async ({ documentName }: { documentName: string }) => {
+    mutationFn: async ({
+      documentId,
+      documentName,
+    }: {
+      documentId: string;
+      documentName: string;
+    }) => {
       if (!notebookId) {
         throw new Error('Cannot delete document without a notebook id');
       }


### PR DESCRIPTION
## Summary
- include the document id in the delete document mutation payload so the webhook receives it
- update the sidebar delete action to pass the selected document id to the mutation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e547df97508326a392b30b90d489d2